### PR TITLE
Add list_run_paths and list_run_ids functions to mlflow module

### DIFF
--- a/src/hydraflow/__init__.py
+++ b/src/hydraflow/__init__.py
@@ -3,7 +3,13 @@
 from hydraflow.config import select_config, select_overrides
 from hydraflow.context import chdir_artifact, log_run, start_run
 from hydraflow.main import main
-from hydraflow.mlflow import list_runs, search_runs, set_experiment
+from hydraflow.mlflow import (
+    list_run_ids,
+    list_run_paths,
+    list_runs,
+    search_runs,
+    set_experiment,
+)
 from hydraflow.run_collection import RunCollection
 from hydraflow.utils import (
     get_artifact_dir,
@@ -22,6 +28,8 @@ __all__ = [
     "get_artifact_path",
     "get_hydra_output_dir",
     "get_overrides",
+    "list_run_ids",
+    "list_run_paths",
     "list_runs",
     "load_config",
     "load_overrides",

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -92,3 +92,10 @@ def test_list_runs(experiment: Experiment, status, n, n_jobs, func):
     experiment_names = func(experiment.name)
     rc = list_runs(experiment_names=experiment_names, status=status, n_jobs=n_jobs)
     assert len(rc) == n
+
+
+def test_list_run_dirs(experiment: Experiment):
+    from hydraflow.mlflow import list_run_paths
+
+    dirs = list_run_paths(experiment.name, "artifacts")
+    assert all(d.is_dir() for d in dirs)


### PR DESCRIPTION
Refactor mlflow module to introduce two new utility functions:
- list_run_paths: Returns paths of runs for specified experiments
- list_run_ids: Returns run IDs for specified experiments

Update __init__.py to expose these new functions and modify the existing list_runs function to use the new list_run_ids method