### PR TITLE
Rename 'configs' to 'with_' in configuration and executor modules

### DIFF
--- a/src/hydraflow/executor/conf.py
+++ b/src/hydraflow/executor/conf.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 class Step:
     batch: str = ""
     args: str = ""
-    configs: str = ""
+    with_: str = ""
 
 
 @dataclass
@@ -15,7 +15,7 @@ class Job:
     name: str = ""
     run: str = ""
     call: str = ""
-    configs: str = ""
+    with_: str = ""
     steps: list[Step] = field(default_factory=list)
 
 

--- a/src/hydraflow/executor/io.py
+++ b/src/hydraflow/executor/io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from .conf import HydraflowConf
 
@@ -35,7 +35,26 @@ def load_config() -> HydraflowConf:
 
     cfg = OmegaConf.load(path)
 
-    return OmegaConf.merge(schema, cfg)  # type: ignore
+    if not isinstance(cfg, DictConfig):
+        return schema
+
+    rename_with(cfg)
+
+    return OmegaConf.merge(schema, cfg)  # type: ignore[return-value]
+
+
+def rename_with(cfg: DictConfig) -> None:
+    """Rename the `with` field to `with_`."""
+    if "with" in cfg:
+        cfg["with_"] = cfg.pop("with")
+
+    for key in list(cfg.keys()):
+        if isinstance(cfg[key], DictConfig):
+            rename_with(cfg[key])
+        elif isinstance(cfg[key], ListConfig):
+            for item in cfg[key]:
+                if isinstance(item, DictConfig):
+                    rename_with(item)
 
 
 def get_job(name: str) -> Job:

--- a/src/hydraflow/executor/job.py
+++ b/src/hydraflow/executor/job.py
@@ -69,10 +69,10 @@ def iter_batches(job: Job) -> Iterator[list[str]]:
 
     """
     job_name = f"hydra.job.name={job.name}"
-    job_configs = shlex.split(job.configs)
+    job_configs = shlex.split(job.with_)
 
     for step in job.steps:
-        configs = shlex.split(step.configs) or job_configs
+        configs = shlex.split(step.with_) or job_configs
 
         for args in iter_args(step.batch, step.args):
             sweep_dir = f"hydra.sweep.dir=multirun/{ulid.ULID()}"

--- a/tests/cli/hydraflow.yaml
+++ b/tests/cli/hydraflow.yaml
@@ -13,10 +13,10 @@ jobs:
         args: count=100
   parallel:
     run: python app.py
-    configs: hydra/launcher=joblib hydra.launcher.n_jobs=2
+    with: hydra/launcher=joblib hydra.launcher.n_jobs=2
     steps:
       - batch: name=a
         args: count=1:4
       - batch: name=b
         args: count=11:14
-        configs: hydra/launcher=joblib hydra.launcher.n_jobs=4
+        with: hydra/launcher=joblib hydra.launcher.n_jobs=4

--- a/tests/executor/test_conf.py
+++ b/tests/executor/test_conf.py
@@ -25,10 +25,11 @@ def test_none():
 
 
 def test_job(config):
-    cfg = config("jobs:\n  a:\n    run: a.test\n")
+    cfg = config("jobs:\n  a:\n    run: a.test\n    with: --opt1 --opt2\n")
     assert cfg.jobs["a"].run == "a.test"
+    assert cfg.jobs["a"].with_ == "--opt1 --opt2"
 
 
 def test_step(config):
-    cfg = config("jobs:\n  a:\n    steps:\n      - configs: --opt1 --opt2\n")
-    assert cfg.jobs["a"].steps[0].configs == "--opt1 --opt2"
+    cfg = config("jobs:\n  a:\n    steps:\n      - with: --opt1 --opt2\n")
+    assert cfg.jobs["a"].steps[0].with_ == "--opt1 --opt2"

--- a/tests/executor/test_io.py
+++ b/tests/executor/test_io.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from omegaconf import DictConfig
 
 
 @pytest.mark.parametrize("file", ["hydraflow.yaml", "hydraflow.yml"])
@@ -16,3 +17,15 @@ def test_find_config_none(chdir):
     from hydraflow.executor.io import find_config_file
 
     assert find_config_file() is None
+
+
+def test_load_config_list(chdir):
+    from hydraflow.executor.io import load_config
+
+    Path("hydraflow.yaml").write_text("- a\n- b\n")
+
+    cfg = load_config()
+    assert isinstance(cfg, DictConfig)
+    assert cfg.jobs == {}
+
+    Path("hydraflow.yaml").unlink()


### PR DESCRIPTION
- Update configuration dataclasses in `conf.py` to use `with_` instead of `configs`
- Modify `io.py` to add a `rename_with` function for handling configuration renaming
- Update `job.py` to use `with_` when processing job and step configurations
- Adjust test files to reflect the new configuration attribute name
- Add handling for list configurations in `load_config` function
- Improve type checking and configuration parsing logic