### PR TITLE
Enhance CLI and job executor with submit functionality

### DIFF
--- a/src/hydraflow/cli.py
+++ b/src/hydraflow/cli.py
@@ -13,53 +13,86 @@ app = typer.Typer(add_completion=False)
 console = Console()
 
 
-@app.command()
+@app.command(context_settings={"ignore_unknown_options": True})
 def run(
     name: Annotated[str, Argument(help="Job name.", show_default=False)],
     *,
+    args: Annotated[
+        list[str] | None,
+        Argument(help="Arguments to pass to the job.", show_default=False),
+    ] = None,
     dry_run: Annotated[
         bool,
-        Option("--dry-run", help="Perform a dry run"),
+        Option("--dry-run", help="Perform a dry run."),
     ] = False,
 ) -> None:
     """Run a job."""
-
     from hydraflow.executor.io import get_job
-    from hydraflow.executor.job import (
-        iter_batches,
-        iter_calls,
-        iter_runs,
-        submit,
-        to_text,
-    )
+    from hydraflow.executor.job import iter_batches, iter_calls, iter_runs
 
+    args = args or []
     job = get_job(name)
 
-    if dry_run:
-        typer.echo(to_text(job))
-        raise typer.Exit
-
-    import mlflow
-
-    mlflow.set_experiment(job.name)
-
-    if job.submit:
-        funcname, *args = shlex.split(job.submit)
-        submit(funcname, args, iter_batches(job))
-        raise typer.Exit
-
     if job.run:
-        executable, *args = shlex.split(job.run)
-        it = iter_runs(executable, args, iter_batches(job))
+        args = [*shlex.split(job.run), *args]
+        it = iter_runs(args, iter_batches(job), dry_run=dry_run)
     elif job.call:
-        funcname, *args = shlex.split(job.call)
-        it = iter_calls(funcname, args, iter_batches(job))
+        args = [*shlex.split(job.call), *args]
+        it = iter_calls(args, iter_batches(job), dry_run=dry_run)
     else:
         typer.echo(f"No command found in job: {job.name}.")
         raise typer.Exit(1)
 
-    for _ in it:
-        pass
+    if not dry_run:
+        import mlflow
+
+        mlflow.set_experiment(job.name)
+
+    for task in it:  # jobs will be executed here
+        if job.run and dry_run:
+            typer.echo(shlex.join(task.args))
+        elif job.call and dry_run:
+            funcname, *args = task.args
+            arg = ", ".join(f"{arg!r}" for arg in args)
+            typer.echo(f"{funcname}([{arg}])")
+
+
+@app.command(context_settings={"ignore_unknown_options": True})
+def submit(
+    name: Annotated[str, Argument(help="Job name.", show_default=False)],
+    *,
+    args: Annotated[
+        list[str] | None,
+        Argument(help="Arguments to pass to the job.", show_default=False),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        Option("--dry-run", help="Perform a dry run."),
+    ] = False,
+) -> None:
+    """Submit a job."""
+    from hydraflow.executor.io import get_job
+    from hydraflow.executor.job import iter_batches, submit
+
+    args = args or []
+    job = get_job(name)
+
+    if not job.run:
+        typer.echo(f"No run found in job: {job.name}.")
+        raise typer.Exit(1)
+
+    if not dry_run:
+        import mlflow
+
+        mlflow.set_experiment(job.name)
+
+    args = [*shlex.split(job.run), *args]
+    result = submit(args, iter_batches(job), dry_run=dry_run)
+
+    if dry_run and isinstance(result, tuple):
+        for line in result[1].splitlines():
+            args = shlex.split(line)
+            typer.echo(shlex.join([*result[0][:-1], *args]))
 
 
 @app.command()

--- a/src/hydraflow/executor/conf.py
+++ b/src/hydraflow/executor/conf.py
@@ -15,7 +15,6 @@ class Job:
     name: str = ""
     run: str = ""
     call: str = ""
-    submit: str = ""
     with_: str = ""
     steps: list[Step] = field(default_factory=list)
 

--- a/src/hydraflow/executor/job.py
+++ b/src/hydraflow/executor/job.py
@@ -22,7 +22,10 @@ import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
+from subprocess import CompletedProcess
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, overload
 
 import ulid
 
@@ -82,29 +85,49 @@ def iter_batches(job: Job) -> Iterator[list[str]]:
 
 
 @dataclass
-class Run:
-    """An executed run."""
+class Task:
+    """An executed task."""
 
+    args: list[str]
     total: int
     completed: int
+
+
+@dataclass
+class Run(Task):
+    """An executed run."""
+
     result: CompletedProcess
 
 
 @dataclass
-class Call:
+class Call(Task):
     """An executed call."""
 
-    total: int
-    completed: int
     result: Any
 
 
+@overload
+def iter_runs(args: list[str], iterable: Iterable[list[str]]) -> Iterator[Run]: ...
+
+
+@overload
 def iter_runs(
-    executable: str,
     args: list[str],
     iterable: Iterable[list[str]],
-) -> Iterator[Run]:
+    *,
+    dry_run: bool = False,
+) -> Iterator[Task | Run]: ...
+
+
+def iter_runs(
+    args: list[str],
+    iterable: Iterable[list[str]],
+    *,
+    dry_run: bool = False,
+) -> Iterator[Task | Run]:
     """Execute multiple runs of a job using shell commands."""
+    executable, *args = args
     if executable == "python" and sys.platform == "win32":
         executable = sys.executable
 
@@ -112,34 +135,69 @@ def iter_runs(
     total = len(iterable)
 
     for completed, args_ in enumerate(iterable, 1):
-        result = subprocess.run([executable, *args, *args_], check=False)
-        yield Run(total, completed, result)
+        cmd = [executable, *args, *args_]
+        if dry_run:
+            yield Task(cmd, total, completed)
+        else:
+            result = subprocess.run(cmd, check=False)
+            yield Run(cmd, total, completed, result)
+
+
+@overload
+def iter_calls(args: list[str], iterable: Iterable[list[str]]) -> Iterator[Call]: ...
+
+
+@overload
+def iter_calls(
+    args: list[str],
+    iterable: Iterable[list[str]],
+    *,
+    dry_run: bool = False,
+) -> Iterator[Task | Call]: ...
 
 
 def iter_calls(
-    funcname: str,
     args: list[str],
     iterable: Iterable[list[str]],
-) -> Iterator[Call]:
+    *,
+    dry_run: bool = False,
+) -> Iterator[Task | Call]:
     """Execute multiple calls of a job using Python functions."""
+    funcname, *args = args
     func = get_callable(funcname)
 
     iterable = list(iterable)
     total = len(iterable)
 
     for completed, args_ in enumerate(iterable, 1):
-        result = func([*args, *args_])
-        yield Call(total, completed, result)
+        cmd = [funcname, *args, *args_]
+        if dry_run:
+            yield Task(cmd, total, completed)
+        else:
+            result = func([*args, *args_])
+            yield Call(cmd, total, completed, result)
 
 
 def submit(
-    funcname: str,
     args: list[str],
     iterable: Iterable[list[str]],
-) -> Any:
-    """Submit entire job using Python functions."""
-    func = get_callable(funcname)
-    return func([[*args, *a] for a in iterable])
+    *,
+    dry_run: bool = False,
+) -> CompletedProcess | tuple[list[str], str]:
+    """Submit entire job using a shell command."""
+    executable, *args = args
+    if executable == "python" and sys.platform == "win32":
+        executable = sys.executable
+
+    with NamedTemporaryFile(dir=Path.cwd()) as f:
+        file = Path(f.name)
+        text = "\n".join(shlex.join(args) for args in iterable)
+        file.write_text(text)
+        cmd = [executable, *args, file.as_posix()]
+        if dry_run:
+            return cmd, text
+
+        return subprocess.run(cmd, check=False)
 
 
 def get_callable(name: str) -> Callable:
@@ -156,38 +214,3 @@ def get_callable(name: str) -> Callable:
     except (ImportError, AttributeError, ModuleNotFoundError) as e:
         msg = f"Failed to import or find function: {name}"
         raise ValueError(msg) from e
-
-
-def to_text(job: Job) -> str:
-    """Convert the job configuration to a string.
-
-    This function returns the job configuration for a given job.
-
-    Args:
-        job (Job): The job configuration to show.
-
-    Returns:
-        str: The job configuration.
-
-    """
-    text = ""
-
-    it = iter_batches(job)
-
-    if job.run:
-        base_cmds = shlex.split(job.run)
-        for args in it:
-            cmds = " ".join([*base_cmds, *args])
-            text += f"{cmds}\n"
-
-    elif job.call:
-        text = f"call: {job.call}\n"
-        for args in it:
-            text += f"args: {args}\n"
-
-    elif job.submit:
-        text = f"submit: {job.submit}\n"
-        for args in it:
-            text += f"args: {args}\n"
-
-    return text.rstrip()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -10,3 +10,5 @@ def setup(chdir):
     copy(src, src.name)
     src = Path(__file__).parent / "app.py"
     copy(src, src.name)
+    src = Path(__file__).parent / "submit.py"
+    copy(src, src.name)

--- a/tests/cli/hydraflow.yaml
+++ b/tests/cli/hydraflow.yaml
@@ -28,12 +28,14 @@ jobs:
       - batch: name=c,d
         args: count=4:6
   submit:
-    submit: typer.echo
+    run: python submit.py
     steps:
-      - batch: name=a
-        args: count=1,3
-      - batch: name=b
-        args: count=5,7
+      - batch: name=a,b
+        args: count=1
+      - batch: name=c
+        args: count=5
+      - batch: name=d
+        args: count=6
   error:
     steps:
       - batch: name=a

--- a/tests/cli/submit.py
+++ b/tests/cli/submit.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    file = Path(sys.argv[-1])
+    for line in file.read_text().splitlines():
+        args = shlex.split(line)
+        subprocess.run(["python", "app.py", *args], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -11,9 +11,9 @@ def test_run_args_dry_run():
     result = runner.invoke(app, ["run", "args", "--dry-run"])
     assert result.exit_code == 0
     out = result.stdout
-    assert "hydra.job.name=args" in out
-    assert "count=1,2,3 name=a,b" in out
-    assert "count=4,5,6 name=c,d" in out
+    assert "python app.py --multirun count=1,2,3 name=a,b" in out
+    assert "python app.py --multirun count=4,5,6 name=c,d" in out
+    assert out.count("hydra.job.name=args") == 2
 
 
 def test_run_batch_dry_run():
@@ -24,7 +24,7 @@ def test_run_batch_dry_run():
     assert "name=b count=1,2" in out
     assert "name=c,d count=100" in out
     assert "name=e,f count=100" in out
-    assert "hydra.job.name=batch" in out
+    assert out.count("hydra.job.name=batch") == 4
 
 
 def test_run_parallel_dry_run():
@@ -37,6 +37,27 @@ def test_run_parallel_dry_run():
     assert "hydra.launcher.n_jobs=2" in lines[0]
     assert "count=11,12,13,14" in lines[1]
     assert "hydra.launcher.n_jobs=4" in lines[1]
+
+
+def test_run_parallel_dry_run_extra_args():
+    args = ["run", "parallel", "--dry-run", "a", "--b", "--", "--dry-run"]
+    result = runner.invoke(app, args)
+    assert result.exit_code == 0
+    assert result.stdout.count("python app.py a --b --dry-run --multirun") == 2
+
+
+def test_run_echo_dry_run():
+    args = ["run", "echo", "--dry-run"]
+    result = runner.invoke(app, args)
+    assert result.exit_code == 0
+    assert result.stdout.count("typer.echo(['a', 'b', 'c', '--multirun',") == 4
+
+
+def test_submit_dry_run():
+    args = ["submit", "submit", "--dry-run", "a", "--b", "--", "--dry-run"]
+    result = runner.invoke(app, args)
+    assert result.exit_code == 0
+    assert result.stdout.count("python submit.py a --b --dry-run --multirun") == 4
 
 
 @pytest.mark.xdist_group(name="group1")
@@ -77,13 +98,14 @@ def test_run_echo():
 
 
 @pytest.mark.xdist_group(name="group4")
-def test_run_submit():
-    result = runner.invoke(app, ["run", "submit"])
+def test_submit():
+    result = runner.invoke(app, ["submit", "submit"])
     assert result.exit_code == 0
     out = result.stdout
     lines = out.splitlines()
-    assert len(lines) == 2
-    assert "[['--multirun', 'name=a', 'count=1,3', 'hydra.job.name=submit'" in lines[1]
+    assert len(lines) == 1
+    run_ids = hydraflow.list_run_ids("submit")
+    assert len(run_ids) == 4
 
 
 @pytest.mark.xdist_group(name="group5")
@@ -91,3 +113,10 @@ def test_run_error():
     result = runner.invoke(app, ["run", "error"])
     assert result.exit_code == 1
     assert "No command found in job: error." in result.stdout
+
+
+@pytest.mark.xdist_group(name="group5")
+def test_submit_error():
+    result = runner.invoke(app, ["submit", "error"])
+    assert result.exit_code == 1
+    assert "No run found in job: error." in result.stdout

--- a/tests/executor/echo.py
+++ b/tests/executor/echo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/tests/executor/read.py
+++ b/tests/executor/read.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main():
+    path = Path(sys.argv[1])
+    src = Path(sys.argv[2])
+    text = src.read_text()
+    path.write_text(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Updated the `run` command to accept additional arguments and handle dry runs.
- Introduced a new `submit` command for job submission with similar argument handling.
- Refactored job execution logic to support dry runs and improved output formatting.
- Removed the unused `submit` attribute from the `Job` class.
- Added tests for the new `submit` command and enhanced existing tests for better coverage.