### PR TITLE
Enhance the `get` method in the Run class to accept a callable as a default value

### DIFF
--- a/docs/part3-analysis/run-class.md
+++ b/docs/part3-analysis/run-class.md
@@ -62,6 +62,16 @@ model_type = run.get("model__type")  # Equivalent to "model.type"
 # Access implementation attributes or run info
 metric_value = run.get("accuracy")  # From impl or cfg
 run_id = run.get("run_id")  # From RunInfo
+
+# Provide a default value if the key doesn't exist
+batch_size = run.get("batch_size", 32)
+
+# Use a callable as default to dynamically generate values based on the run
+# This is useful for derived parameters or conditional defaults
+lr = run.get("learning_rate", default=lambda r: r.get("base_lr", 0.01) / 10)
+
+# Complex default logic based on other parameters
+steps = run.get("steps", default=lambda r: r.get("epochs", 10) * r.get("steps_per_epoch", 100))
 ```
 
 The `get` method searches for values in the following order:
@@ -75,6 +85,16 @@ This provides a unified access interface regardless of where the data is stored.
 The double underscore notation (`__`) is automatically converted to dot notation (`.`) internally,
 making it useful for nested parameter access, especially when using keyword arguments in methods
 that don't allow dots in parameter names.
+
+When providing a default value, you can use either a static value or a callable function.
+If you provide a callable, it will receive the Run instance as an argument, allowing you to
+create context-dependent default values that can access other run parameters or properties.
+This is particularly useful for:
+
+- Creating derived parameters that don't exist in the original configuration
+- Handling schema evolution across different experiment iterations
+- Providing fallbacks that depend on other configuration values
+- Implementing conditional logic for parameter defaults
 
 ## Type-Safe Configuration Access
 

--- a/docs/part3-analysis/run-collection.md
+++ b/docs/part3-analysis/run-collection.md
@@ -123,7 +123,22 @@ complex_filter = runs.filter(
 
 # Chained filtering
 final_runs = runs.filter(model_type="transformer").filter(learning_rate=0.001)
+
+# Advanced filtering using predicate functions with callable defaults
+# This example filters runs based on learning rate efficiency (lr * batch_size)
+# Even if some runs are missing one parameter, the default logic provides values
+def has_efficient_lr(run: Run) -> bool:
+    lr = run.get("learning_rate", default=lambda r: r.get("base_lr", 0.01) * r.get("lr_multiplier", 1.0))
+    batch_size = run.get("batch_size", default=lambda r: r.get("default_batch_size", 32))
+    return lr * batch_size < 0.5
+
+# Apply the complex predicate
+efficient_runs = runs.filter(predicate=has_efficient_lr)
 ```
+
+The combination of predicate functions with callable defaults in `get` enables sophisticated
+filtering logic that can handle missing parameters and varied configuration schemas across
+different experiment runs.
 
 ## Sorting Runs
 

--- a/docs/part3-analysis/updating-runs.md
+++ b/docs/part3-analysis/updating-runs.md
@@ -96,7 +96,21 @@ def calculate_aspect_ratio(run: Run) -> float:
 
 # Update with calculated values
 runs.update("aspect_ratio", calculate_aspect_ratio)
+
+# Combine with callable defaults for more sophisticated logic
+runs.update("normalized_lr", lambda run: run.get(
+    "learning_rate",
+    default=lambda r: r.get("base_lr", 0.01) * r.get("lr_multiplier", 1.0)
+) / 10)
 ```
+
+The combination of dynamic updates with callable defaults in `get` provides a powerful
+mechanism for handling complex configuration scenarios and parameter dependencies. This
+approach allows you to:
+
+1. First look for existing values with custom fallback logic using `get` with callable defaults
+2. Then compute new parameters based on those values with `update`
+3. Finally ensure all runs have consistent parameters for analysis
 
 ## Updating Multiple Parameters
 

--- a/src/hydraflow/core/run.py
+++ b/src/hydraflow/core/run.py
@@ -252,13 +252,15 @@ class Run[C, I = None]:
             if force or OmegaConf.select(cfg, k_, default=MISSING) is MISSING:
                 OmegaConf.update(cfg, k_, v, force_add=True)
 
-    def get(self, key: str, default: Any = MISSING) -> Any:
+    def get(self, key: str, default: Any | Callable[[Self], Any] = MISSING) -> Any:
         """Get a value from the information or configuration.
 
         Args:
             key: The key to look for. Can use dot notation for
                 nested keys in configuration.
             default: Value to return if the key is not found.
+                If a callable, it will be called with the Run instance
+                and the value returned will be used as the default.
                 If not provided, AttributeError will be raised.
 
         Returns:
@@ -285,6 +287,9 @@ class Run[C, I = None]:
             return info[key]
 
         if default is not MISSING:
+            if callable(default):
+                return default(self)
+
             return default
 
         msg = f"No such key: {key}"

--- a/tests/core/run/test_run.py
+++ b/tests/core/run/test_run.py
@@ -116,6 +116,11 @@ def test_get_default(run: Run[Config]):
     assert run.get("unknown", 10) == 10
 
 
+def test_get_default_callable(run: Run[Config]):
+    run.update("a", 1000)
+    assert run.get("unknown", lambda run: run.get("a")) == 1000
+
+
 def test_get_info(run: Run[Config]):
     assert run.get("run_dir") == "."
 


### PR DESCRIPTION
This allows for dynamic default value generation based on the Run instance. Add a corresponding test to verify this new functionality.