### PR TITLE
Add `preload` method to `RunCollection` for parallel loading of confi…

### DIFF
--- a/tests/core/run/test_run_collection.py
+++ b/tests/core/run/test_run_collection.py
@@ -88,6 +88,14 @@ def test_iter(rc: Rc):
     assert len(list(iter(rc))) == 12
 
 
+def test_preload(rc: Rc):
+    assert rc.preload(cfg=True, impl=True) is rc
+
+
+def test_preload_n_jobs(rc: Rc):
+    assert rc.preload(cfg=True, impl=True, n_jobs=2) is rc
+
+
 def test_update(rc: Rc):
     rc.update("size.height", 10)
     assert all(r.get("size.height") is None for r in rc)


### PR DESCRIPTION
…guration and implementation objects

Implement a new `preload` method that allows for preloading of configuration and implementation objects for all runs in the collection, with support for parallel execution using joblib. Add corresponding tests to validate the new functionality.