### PR TITLE
Add iterdir and glob methods to Run and RunCollection classes

### DIFF
--- a/src/hydraflow/core/run.py
+++ b/src/hydraflow/core/run.py
@@ -375,6 +375,31 @@ class Run[C, I = None]:
         """
         return self.info.run_dir / "artifacts" / relative_path
 
+    def iterdir(self, relative_dir: str = "") -> Iterator[Path]:
+        """Iterate over the artifact directories for the run.
+
+        Args:
+            relative_dir (str): The relative directory to iterate over.
+
+        Yields:
+            Path: The artifact directory for the run.
+
+        """
+        yield from self.path(relative_dir).iterdir()
+
+    def glob(self, pattern: str, relative_dir: str = "") -> Iterator[Path]:
+        """Glob the artifact directories for the run.
+
+        Args:
+            pattern (str): The pattern to glob.
+            relative_dir (str): The relative directory to glob.
+
+        Yields:
+            Path: The existing artifact paths that match the pattern.
+
+        """
+        yield from self.path(relative_dir).glob(pattern)
+
 
 def _flatten_dict(d: dict[str, Any], parent_key: str = "") -> dict[str, Any]:
     items = []

--- a/src/hydraflow/core/run_collection.py
+++ b/src/hydraflow/core/run_collection.py
@@ -44,7 +44,8 @@ from .collection import Collection
 from .run import Run
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Iterator
+    from pathlib import Path
     from typing import Any, Self
 
 
@@ -166,10 +167,37 @@ class RunCollection[R: Run[Any, Any], I = None](Collection[R]):
 
     @cached_property
     def impls(self) -> Collection[I]:
-        """Get the implementation object for all runs in the collection.
+        """Get the implementation objects for all runs in the collection.
 
         Returns:
             Collection[Any]: A collection of implementation objects for all runs.
 
         """
         return Collection(run.impl for run in self)
+
+    def iterdir(self, relative_dir: str = "") -> Iterator[Path]:
+        """Iterate over the artifact directories for all runs in the collection.
+
+        Args:
+            relative_dir (str): The relative directory to iterate over.
+
+        Returns:
+            Iterator[Path]: An iterator over the artifact directories for all runs.
+
+        """
+        for run in self:
+            yield from run.iterdir(relative_dir)
+
+    def glob(self, pattern: str, relative_dir: str = "") -> Iterator[Path]:
+        """Glob the artifact directories for all runs in the collection.
+
+        Args:
+            pattern (str): The pattern to glob.
+            relative_dir (str): The relative directory to glob.
+
+        Returns:
+            Iterator[Path]: An iterator over the artifact directories for all runs.
+
+        """
+        for run in self:
+            yield from run.glob(pattern, relative_dir)

--- a/tests/core/run/test_run.py
+++ b/tests/core/run/test_run.py
@@ -279,3 +279,17 @@ def test_chdir(run_impl_config: Run[Dummy, ImplConfig]):
     with run.chdir():
         Path("a.txt").write_text("a")
     assert run.path("a.txt").read_text() == "a"
+
+
+@pytest.fixture(scope="module")
+def rc(results):
+    run_dir: Path = results[0][0].parent
+    return Run[Dummy, ImplConfig].load([run_dir, run_dir], ImplConfig)
+
+
+def test_iterdir_glob(rc: RunCollection[Run[Dummy, ImplConfig]]):
+    for run in rc:
+        run.path("a.txt").write_text("a")
+
+    assert len(list(rc.iterdir())) == 6
+    assert len(list(rc.glob("*.txt"))) == 2


### PR DESCRIPTION
- Implemented iterdir and glob methods in both Run and RunCollection classes to facilitate iteration and pattern matching over artifact directories.
- Enhanced documentation for the new methods to clarify their usage and parameters.
- Added tests to validate the functionality of the iterdir and glob methods in the RunCollection class.