### PR TITLE
Add dry run functionality to main execution flow

### DIFF
--- a/src/hydraflow/core/collection.py
+++ b/src/hydraflow/core/collection.py
@@ -486,7 +486,7 @@ class Collection[I](Sequence[I]):
                 for the keys. If a callable, it will be called with the item and the
                 value returned will be used as the default.
             n_jobs (int): Number of jobs to run in parallel. 0 means no parallelization.
-                Default is 0.
+                Default to 0.
             backend (str): Parallelization backend.
             progress (bool): Whether to display a progress bar.
             **kwargs (Callable[[I], Any]): Additional columns to compute using

--- a/tests/core/main/test_dry_run.py
+++ b/tests/core/main/test_dry_run.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def results(collect):
+    file = Path(__file__).parent / "update.py"
+    collect(file, ["width=1", "height=1"])
+    return collect(file, ["-m", "width=2,3", "height=4,5", "--dry-run"])
+
+
+def test_len(results):
+    assert len(results) == 1
+
+
+def test_log():
+    file = Path(__file__).parent.joinpath("update.py").as_posix()
+    args = [sys.executable, file, "-m", "width=2,3", "height=4,5", "--dry-run"]
+    out = subprocess.check_output(args, text=True)
+    assert "width: 2\nheight: 4\narea: 8" in out
+    assert "width: 2\nheight: 5\narea: 10" in out
+    assert "width: 3\nheight: 4\narea: 12" in out
+    assert "width: 3\nheight: 5\narea: 15" in out

--- a/tests/core/main/update.py
+++ b/tests/core/main/update.py
@@ -15,18 +15,18 @@ class Config:
     height: int = 0
     area: int = 0
 
+    @staticmethod
+    def update(cfg: Config) -> Config:
+        if cfg.width > 0 and cfg.height > 0:
+            cfg.area = cfg.width * cfg.height
+        elif cfg.width > 0 and cfg.area > 0:
+            cfg.height = cfg.area // cfg.width
+        elif cfg.height > 0 and cfg.area > 0:
+            cfg.width = cfg.area // cfg.height
+        return cfg
 
-def update(cfg: Config) -> Config:
-    if cfg.width > 0 and cfg.height > 0:
-        cfg.area = cfg.width * cfg.height
-    elif cfg.width > 0 and cfg.area > 0:
-        cfg.height = cfg.area // cfg.width
-    elif cfg.height > 0 and cfg.area > 0:
-        cfg.width = cfg.area // cfg.height
-    return cfg
 
-
-@hydraflow.main(Config, chdir=True, update=update)
+@hydraflow.main(Config, chdir=True, update=Config.update)
 def app(run: Run, cfg: Config):
     pass
 


### PR DESCRIPTION
- Introduced a `dry_run` parameter to the `main` function, allowing users to start the hydra job without executing the application.
- Implemented logging to display the configuration in dry run mode.
- Added a new test file to validate the dry run behavior.
- Refactored the update function to be a static method within the Config class.