### PR TITLE
fix: Resolve MLflow initialization race condition by implementing file locking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "python-ulid>=3.0.0",
   "rich>=14",
   "typer>=0.16",
+  "filelock>=3.12.2",
 ]
 
 [project.urls]

--- a/src/hydraflow/cli.py
+++ b/src/hydraflow/cli.py
@@ -33,11 +33,6 @@ def _run(  # pyright: ignore[reportUnusedFunction]
     args = args or []
     job = get_job(name)
 
-    if not dry_run:
-        import mlflow
-
-        mlflow.set_experiment(job.name)
-
     if job.submit:
         submit(job, args, dry_run=dry_run)
 


### PR DESCRIPTION
## Solution

A file lock mechanism has been introduced within the `@main` decorator in the `hydraflow.core.main` module.

### Key Changes

1.  **Added `filelock` library**: The `filelock` library has been added as a new dependency to `pyproject.toml` to enable process-safe file locking.

2.  **Implemented a Global File Lock**:
    -   A lock file (`.mlflow.lock`) is created in the **parent directory** of the sweep directory obtained from `HydraConfig.get().sweep.dir`.
    -   Using this location for the lock prevents race conditions not only within a single sweep (intra-sweep) but also between multiple different sweeps started around the same time (inter-sweep).
    -   This approach also functions safely in single-run scenarios and provides a robust, backend-agnostic solution that is independent of the MLflow backend type (SQLite, remote server, etc.).
    -   Only the critical `mlflow.set_experiment()` call is protected by the lock; the subsequent execution of the application's main logic (`app()`) is not locked, thus preserving parallel execution performance.